### PR TITLE
auto TNCO

### DIFF
--- a/rlsolver/rlsolver_learn2opt/tensor_train/TNCO_env.py
+++ b/rlsolver/rlsolver_learn2opt/tensor_train/TNCO_env.py
@@ -171,7 +171,6 @@ NodesSycamoreN53M20 = [
 
 def get_nodes_list(len_list: int = 4):
     nodes = [[] for _ in range(len_list)]  # 初始化邻接表
-
     for i in range(len_list):
         if i > 0:
             nodes[i].append(i - 1)


### PR DESCRIPTION
auto TNCO 

it can run on DGX2 A100

fix the bug about 
```
    torch.autograd.backward(self, gradient, retain_graph, create_graph, inputs=inputs)
  File "/opt/conda/lib/python3.8/site-packages/torch/autograd/__init__.py", line 173, in backward
    Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
RuntimeError: one of the variables needed for gradient computation has been modified by an inplace operation: [torch.cuda.FloatTensor [256, 1]], which is output 0 of AsStridedBackward0, is at version 5225; expected version 4938 instead. Hint: enable anomaly detection to find the operation that failed to compute its gradient, with torch.autograd.set_detect_anomaly(True).
```

and

```
    loss.backward()
  File "/opt/conda/lib/python3.8/site-packages/torch/_tensor.py", line 396, in backward
    torch.autograd.backward(self, gradient, retain_graph, create_graph, inputs=inputs)
  File "/opt/conda/lib/python3.8/site-packages/torch/autograd/__init__.py", line 173, in backward
    Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
RuntimeError: Trying to backward through the graph a second time (or directly access saved tensors after they have already been freed). Saved intermediate values of the graph are freed when you call .backward() or autograd.grad(). Specify retain_graph=True if you need to backward through the graph a second time or if you need to access saved tensors after calling backward.
```
