### PR TITLE
Update H2O_MISO.py

### DIFF
--- a/rlsolver/rlsolver_learn2opt/tensor_train/H2O_MISO.py
+++ b/rlsolver/rlsolver_learn2opt/tensor_train/H2O_MISO.py
@@ -88,7 +88,8 @@ class OptimizerOpti(nn.Module):
         self.activation = nn.Tanh()
         self.recurs1 = nn.GRUCell(inp_dim, hid_dim)
         self.recurs2 = nn.GRUCell(hid_dim, hid_dim)
-        self.output0 = nn.Linear(hid_dim * self.num_rnn, inp_dim)
+        self.output0 = nn.Linear(hid_dim * self.num_rnn, 1)
+        self.output1 = nn.Linear(hid_dim * self.num_rnn, inp_dim)
         layer_init_with_orthogonal(self.output0, std=0.1)
 
     def forward(self, inp0, hid_):
@@ -96,7 +97,9 @@ class OptimizerOpti(nn.Module):
         hid2 = self.activation(self.recurs2(hid1, hid_[1]))
 
         hid = th.cat((hid1, hid2), dim=1)
-        out = self.output0(hid)
+        out_avg = self.output0(hid)
+        out_res = self.output1(hid)
+        out = out_avg + out_res
         return out, (hid1, hid2)
 
 


### PR DESCRIPTION
https://github.com/AI4Finance-Foundation/ElegantRL_Solver/issues/118

我们曾经在上面的帖子讨论过： 
> **对于解 theta 的不同特征，共用了一样的 LSTM模型参数** ... ... 如果想要推广 'Learn to optimize' 到其他问题，那么就需要把 theta的特征维度从 batch size 维度移动到 `inp_dim` 或者 `out_dim` 上

现在发现，这两种选择并不是冲突的，我们可以仿照 DuelingDQN的思路：既让 network 同时学习：
- 不同离散动作对应的Q值的平均
- Q值对应不同离散动作的残差

https://github.com/AI4Finance-Foundation/ElegantRL/blob/0c019eec035391dbe7aca1464ed6a0067e5a130f/elegantrl/agents/net.py#L51-L67

```
class QNetDuel(QNetBase):  # Dueling DQN
    def __init__(self, dims: [int], state_dim: int, action_dim: int):
        super().__init__(state_dim=state_dim, action_dim=action_dim)
        self.net_state = build_mlp(dims=[state_dim, *dims])
        self.net_adv = build_mlp(dims=[dims[-1], 1])  # advantage value
        self.net_val = build_mlp(dims=[dims[-1], action_dim])  # Q value

    def forward(self, state):
        ...
        q_val = self.net_val(s_enc)  # q value
        q_adv = self.net_adv(s_enc)  # advantage value
        value = q_val - q_val.mean(dim=1, keepdim=True) + q_adv  # dueling Q value
        ...
```

如果用到“NP-hard 的 最优化问题上”，我们也可以让 network 学习，然后让网络同时学习：
- 解theta的梯度 对应不同特征的平均值
- 解theta的梯度 对应不同特征的残差


```
class OptimizerOpti(nn.Module):
    def __init__(self, inp_dim: int, hid_dim: int):
        ...
        self.output0 = nn.Linear(hid_dim * self.num_rnn, 1)
        self.output1 = nn.Linear(hid_dim * self.num_rnn, inp_dim)

    def forward(self, inp0, hid_):
        ...
        hid = th.cat((hid1, hid2), dim=1)
        out_avg = self.output0(hid)
        out_res = self.output1(hid)
        out = out_avg + out_res
        return out, (hid1, hid2)
```

只修改了3行，就提速 我们 Graph MaxCut 的任务了，改了这几行代码，其他地方不需要改动

直接就能去测 TNCO问题。 @ZhangAIPI  @spicywei  有空就测测吧。